### PR TITLE
tf.mul -> tf.multiply

### DIFF
--- a/genadv1.ipynb
+++ b/genadv1.ipynb
@@ -342,7 +342,7 @@
     "with tf.variable_scope(\"G\"):\n",
     "    z_node=tf.placeholder(tf.float32, shape=(M,1)) # M uniform01 floats\n",
     "    G,theta_g=mlp(z_node,1) # generate normal transformation of Z\n",
-    "    G=tf.mul(5.0,G) # scale up by 5 to match range\n",
+    "    G=tf.multiply(5.0,G) # scale up by 5 to match range\n",
     "with tf.variable_scope(\"D\") as scope:\n",
     "    # D(x)\n",
     "    x_node=tf.placeholder(tf.float32, shape=(M,1)) # input M normally distributed floats\n",


### PR DESCRIPTION
As tf.mul, tf.sub and tf.neg are deprecated in favor of tf.multiply, tf.subtract and tf.negative in tensorflow 1.0.0.rc1 release.
reference: https://github.com/tensorflow/tensorflow/releases/tag/v1.0.0-rc1