### PR TITLE
Removed deprecated op

### DIFF
--- a/genadv1.ipynb
+++ b/genadv1.ipynb
@@ -369,7 +369,7 @@
    "outputs": [],
    "source": [
     "sess=tf.InteractiveSession()\n",
-    "tf.initialize_all_variables().run()"
+    "tf.global_variables_initializer().run()"
    ]
   },
   {

--- a/genadv1.ipynb
+++ b/genadv1.ipynb
@@ -159,7 +159,7 @@
    "outputs": [],
    "source": [
     "sess=tf.InteractiveSession()\n",
-    "tf.initialize_all_variables().run()"
+    "tf.global_variables_initializer().run()"
    ]
   },
   {


### PR DESCRIPTION
Using `tf.initialize_all_variables()` gives the following warning : 
initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.global_variables_initializer` instead.